### PR TITLE
Fixed broken Lecture 4 notebook. Missing closing quotes on a string

### DIFF
--- a/deeplearning1/DeepLearning4-LectureNotes.ipynb
+++ b/deeplearning1/DeepLearning4-LectureNotes.ipynb
@@ -42,7 +42,7 @@
     "\n",
     "### Vocab:\n",
     "\n",
-    "**activation** - a number that's been calculated from weights, aka parameters, and some of the activations in the previous layer
+    "**activation** - a number that's been calculated from weights, aka parameters, and some of the activations in the previous layer",
     "\n",
     "#### Looking at the Dog Breeds CNN model, let's look at the different layers\n",
     "Looking at Dogbreeds lets' look at the layers:\n",


### PR DESCRIPTION
Fix for issue #4 
For some reason, lecture 4 notebook had one line that was missing a closing double quote and a comma on line 45:

"**activation** - a number that's been calculated from weights, aka parameters, and some of the activations in the previous layer

Added closing double quote and a comma